### PR TITLE
add dependency on chk-lib

### DIFF
--- a/cur-test/info.rkt
+++ b/cur-test/info.rkt
@@ -1,7 +1,7 @@
 #lang info
 (define collection 'multi)
 (define deps '())
-(define build-deps '("base" "rackunit-lib" ("cur-lib" #:version "0.33") "sweet-exp-lib"))
+(define build-deps '("base" "rackunit-lib" ("cur-lib" #:version "0.33") "sweet-exp-lib" "chk-lib"))
 (define update-implies '("cur-lib"))
 (define pkg-desc "Tests for \"cur\".")
 (define pkg-authors '(wilbowma))


### PR DESCRIPTION
Do not merge this commit until https://pkgd.racket-lang.org/pkgn/package/chk-lib has been indexed.