### PR TITLE
stdlib/sugar, stdlib/sized: use #:where turnstile premise option

### DIFF
--- a/cur-lib/cur/stdlib/sized.rkt
+++ b/cur-lib/cur/stdlib/sized.rkt
@@ -199,15 +199,11 @@
      ;; - needed to check size-preservation fns
      ;; tycheck-rel used by typerules themselves
      ;; - needed for termination check of rec calls
-     #:do[(define old-tycheck (current-check-relation))
-          (current-typecheck-relation ; new typecheck-relation with termination guard check
-           (mk-tycheck/sz old-tycheck))
-          (current-check-relation (current-typecheck-relation))]
      [([x+pat ≫ x+pat- : x+patτ] ...)
       ([name ≫ name- : (Π [x : ty-to-match<] ... ty_out<)])
-      ⊢ body ≫ body- ⇐ ty_out] ...
-     #:do[(current-check-relation old-tycheck)
-          (current-typecheck-relation old-tycheck)]
+      ⊢ [body ≫ body- ⇐ ty_out]
+      #:where typecheck-relation (mk-tycheck/sz old-typecheck-relation)
+      #:where check-relation (current-typecheck-relation)] ...
      #:do[(define arity (stx-length #'(x ...)))]
      #:with ((x*- ...) ...) (stx-map
                              (λ (x+pats)
@@ -293,16 +289,12 @@
                                           #`(#,@#'((x ty_in1) ...) ; append x+tyin1 with pat binders and tys
                                              #,@x+τs))
                                         #'(([xpat xpatτ] ...) ...))
-     #:do[(define old-tycheck (current-typecheck-relation))
-          (current-typecheck-relation ; new typecheck-relation with termination guard check
-           (mk-tycheck/sz old-tycheck))]
-     
      [([x+pat ≫ x+pat- : x+patτ] ...)
       ([y ≫ y*- : ty_in2] ...
        ;; for now, assume recursive references are fns
        [name ≫ name- : (Π [x : ty_in1] ... [x0 : ty-to-match<] ... [y : ty_in2] ... ty_out)])
-      ⊢ body ≫ body- ⇐ ty_out] ...
-     #:do[(current-typecheck-relation old-tycheck)]
+      ⊢ [body ≫ body- ⇐ ty_out]
+      #:where typecheck-relation (mk-tycheck/sz old-typecheck-relation)] ...
      #:do[(define arity (stx-length #'(x ... ty-to-match ... y ...)))]
      #:with ((x*- ...) ...) (stx-map
                              (λ (x+pats)

--- a/cur-test/cur/tests/stdlib/sugar.rkt
+++ b/cur-test/cur/tests/stdlib/sugar.rkt
@@ -73,3 +73,30 @@
        [y (λ (x : (Type 1)) x)])
    (y x))
  #:with-msg "λ: no expected type, add annotations")
+
+;; the following tests that typecheck-relation properly restored
+;; (even after err);
+;; thanks to Paul Wang (@pwang347) for finding the problem (see pr#101)
+
+(require cur/stdlib/bool)
+
+(typecheck-fail/toplvl
+ (define/rec/match sub1-bad2 : Nat -> Bool
+   [Z => Z]
+   [(S x) => x])
+ #:with-msg "expected Bool, given Nat.*expression: Z")
+
+(begin-for-syntax
+  (require rackunit)
+  (check-true ;; should ignore prop and succesfully typecheck
+   ;; but fails if sub1-bad2 def does not properly restore tycheck-relation
+   ((current-typecheck-relation) #'Nat (syntax-property #'Nat 'recur #t))))
+
+(define/rec/match multi-pat : Nat Nat Nat -> Nat
+  [_ _ Z => Z]
+  [n m (S l-1) => (multi-pat n m l-1)])
+
+(begin-for-syntax
+  (check-true ;; should ignore prop and succesfully typecheck
+   ;; but fails if sub1-bad2 def does not properly restore tycheck-relation
+   ((current-typecheck-relation) #'Nat (syntax-property #'Nat 'recur #t))))


### PR DESCRIPTION
requires latest turnstile `cur` branch