### PR TITLE
fixes #121 destruct sigma types

### DIFF
--- a/cur-lib/cur/ntac/standard.rkt
+++ b/cur-lib/cur/ntac/standard.rkt
@@ -388,7 +388,7 @@
                   (mk-update #:inst #'(C Aval ... . new-xs) #:idxs (get-idxs #'τout)))
                 (define (update-ctxt old-ctxt)
                   (define tmp-ctxt
-                    (ctx-adds ctxt-unchanged #'new-xs #'(τ ...) #:do normalize))
+                    (ctx-adds ctxt-unchanged #'new-xs #'(τ ...) #:do normalize/nocheck))
                   (ctx-append tmp-ctxt
                               (ctx-map
                                (compose (normalize/ctxt tmp-ctxt) update-ty)

--- a/cur-lib/cur/ntac/utils.rkt
+++ b/cur-lib/cur/ntac/utils.rkt
@@ -5,7 +5,7 @@
  syntax/parse
  syntax/id-set
  (for-template turnstile+/eval
-               (only-in macrotypes/typecheck-core substs)
+               (only-in macrotypes/typecheck-core substs current-typecheck-relation)
                (only-in cur/curnel/lang #%plain-lambda #%plain-app))
  macrotypes/stx-utils
  cur/curnel/reflection
@@ -17,6 +17,9 @@
 
 (define (normalize ty ctxt)
   (cur-normalize (reflect ty) #:local-env (ctx->env ctxt)))
+(define (normalize/nocheck ty ctxt)
+  (parameterize ([current-typecheck-relation (λ (t1 t2) #t)])
+    (normalize ty ctxt)))
 (define ((normalize/ctxt ctxt) ty) (normalize ty ctxt)) ; curried version
 
 (define ((mk-bind-stxf f) x ty)

--- a/cur-test/cur/tests/ntac/destruct-exist.rkt
+++ b/cur-test/cur/tests/ntac/destruct-exist.rkt
@@ -1,0 +1,68 @@
+#lang cur
+
+;; issue #121, from @dmelcer9
+
+(require cur/stdlib/list
+         cur/stdlib/bool
+         cur/stdlib/prop
+         cur/stdlib/sugar
+         cur/stdlib/sigma
+         cur/stdlib/equality
+         cur/ntac/base
+         cur/ntac/standard
+         cur/ntac/rewrite
+         "rackunit-ntac.rkt")
+
+;; ok
+#;(ntac/trace
+   (∀
+    (Σ (lst : (List Bool)) (And (== (List Bool) lst (nil Bool)) (Not (== (List Bool) lst (nil Bool)))))
+    False)
+   (by-intros ex)
+   (by-destruct ex #:as [(aa bb)]))
+;; fails
+(define-theorem f
+  (∀
+   (T : Type)
+   (Σ (lst : (List T))
+      (And (== (List T) lst (nil T))
+           (Not (== (List T) lst (nil T)))))
+   False)
+  (by-intro S)
+  (by-intro ex)
+  (by-destruct ex #:as [(aa bb)])
+  (by-destruct bb #:as [(p pf)])
+  (by-apply pf #:in p)
+  by-assumption)
+
+(:: f
+    (∀ (T : Type)
+       (Σ (lst : (List T))
+          (And (== (List T) lst (nil T))
+               (Not (== (List T) lst (nil T)))))
+       False))
+
+;; should work
+;; (define core
+;;   (ntac
+;;    (∀ (T : Type)
+;;       (x : T)
+;;       (y : T)
+;;       (And (== T x y) (Not (== T x y)))
+;;       False)
+;;    (by-intros T x y p)
+;;    (by-destruct p #:as [(p pf)])
+;;    (by-apply pf #:in p)
+;;    by-assumption))
+
+;; (define val (λ (T : Type)
+;;               (Ex : (Σ (lst : (List T)) (And (== (List T) lst (nil T)) (Not (== (List T) lst (nil T))))))
+;;               (core (List T) (fst Ex) (nil T) (snd Ex))))
+
+;; (define verify-expected-type
+;;   (ntac
+;;    (∀
+;;     (T : Type)
+;;     (Σ (lst : (List T)) (And (== (List T) lst (nil T)) (Not (== (List T) lst (nil T)))))
+;;     False)
+;;    (by-exact val)))

--- a/cur-test/cur/tests/ntac/destruct-exist.rkt
+++ b/cur-test/cur/tests/ntac/destruct-exist.rkt
@@ -20,7 +20,8 @@
     False)
    (by-intros ex)
    (by-destruct ex #:as [(aa bb)]))
-;; fails
+
+;; fails before issue#121 fix
 (define-theorem f
   (∀
    (T : Type)


### PR DESCRIPTION
This is a temporary fix but it got me thinking, should we disable type checking completely while running tactics? The final term will be type checked anyways right?