### PR TITLE
support new turnstile/typedef v0.5.6: no eval for ty/internal table

### DIFF
--- a/cur-lib/cur/curnel/cic-saccharata.rkt
+++ b/cur-lib/cur/curnel/cic-saccharata.rkt
@@ -428,7 +428,7 @@
   ; Differs from turnstile+ get-match-info: accepts type's internal id instead of entire type
   ; - returns the match-info, or #f
   (define (get-match-info I)
-    (define d (eval-syntax I))
+    (define d (get-dict I))
     (and (dict? d) (dict-ref d #'get-datatype-info #f)))
 
   (define (get-datatype-elim ty)

--- a/cur-lib/info.rkt
+++ b/cur-lib/info.rkt
@@ -2,7 +2,7 @@
 (define collection 'multi)
 (define deps
   '(("base" #:version "7.6")
-    ("turnstile-lib" #:version "0.5.3")
+    ("turnstile-lib" #:version "0.5.6")
     ("macrotypes-lib" #:version "0.3.3")
     "reprovide-lang-lib"))
 (define build-deps '())


### PR DESCRIPTION
Don't merge yet, but need this to be compatible with an upcoming turnstile update